### PR TITLE
Support multiple instances of same header.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for perl module AnyEvent::UserAgent
 
+0.08    2024-11-06
+        - Support sending multiple values for a single header.
+
 0.07    2014-09-02
         - Fixed cookie handling (thanks to Eric Johnson).
 

--- a/lib/AnyEvent/UserAgent.pm
+++ b/lib/AnyEvent/UserAgent.pm
@@ -13,7 +13,7 @@ use HTTP::Response ();
 
 use namespace::clean;
 
-our $VERSION = '0.07';
+our $VERSION = '0.08';
 
 
 has agent              => (is => 'rw', default => sub { $AnyEvent::HTTP::USERAGENT . ' AnyEvent-UserAgent/' . $VERSION });
@@ -82,7 +82,7 @@ sub _request {
 	$grd = AnyEvent::HTTP::http_request(
 		$req->method,
 		$req->uri,
-		headers => {map { $_ => $hdrs->header($_) } $hdrs->header_field_names},
+		headers => {map { $_ => scalar($hdrs->header($_)) } $hdrs->header_field_names},
 		body    => $req->content,
 		recurse => 0,
 		timeout => $opts->{inactivity_timeout},

--- a/t/01-headers.t
+++ b/t/01-headers.t
@@ -19,11 +19,13 @@ use AnyEvent::UserAgent ();
 
 		ok exists($opts{headers});
 		is ref($opts{headers}), 'HASH';
-		ok keys(%{$opts{headers}}) == 2;
+		ok keys(%{$opts{headers}}) == 3;
 
 		ok exists($opts{headers}{'X-Foo'});
 		is $opts{headers}{'X-Foo'}, 'bar';
 		ok exists($opts{headers}{'User-Agent'});
+		ok exists($opts{headers}{'X-Multi'});
+		is $opts{headers}{'X-Multi'}, 'foo, bar';
 
 		$cb->('', {Status => 200});
 	};
@@ -32,7 +34,7 @@ use AnyEvent::UserAgent ();
 my $ua = AnyEvent::UserAgent->new;
 my $cv = AE::cv;
 
-$ua->get('http://example.com/', 'X-Foo' => 'bar', sub { $cv->send(); });
+$ua->get('http://example.com/', 'X-Foo' => 'bar', 'X-Multi' => 'foo', 'X-Multi' => 'bar', sub { $cv->send(); });
 $cv->recv();
 
 


### PR DESCRIPTION
Currently, passing the same header multiple times to a UserAgent method does not work as the header method of HTTP::Request returns a list of the value, which breaks the map operation builing the headers argument to AnyEvent::HTTP::http_request. This is fixed now by calling header in scalar context.

It’s not perfect as it will concatenate all the values of the header in a single one. However this is reasonable as this is supposed to have the same meaning for a web server and it seems that AnyEvent::HTTP does not support multiple instances of the same header currently in any case.