### PR TITLE
Add options in the constructors that can be passed to the http_request calls

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for perl module AnyEvent::UserAgent
 
+0.09    2024-11-10
+        - Add more class options that can be passed to all requests (#6, Mathias
+          Kende).
+
 0.08    2024-11-08
         - Support sending multiple values for a single header (#5, Mathias
           Kende).

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for perl module AnyEvent::UserAgent
 0.09    2024-11-10
         - Add more class options that can be passed to all requests (#6, Mathias
           Kende).
+        - Support sending HTTP PATCH and OPTIONS requests (#6, Mathias Kende).
 
 0.08    2024-11-08
         - Support sending multiple values for a single header (#5, Mathias

--- a/lib/AnyEvent/UserAgent.pm
+++ b/lib/AnyEvent/UserAgent.pm
@@ -49,6 +49,8 @@ sub head   { _do_request(\&HTTP::Request::Common::HEAD   => @_) }
 sub put    { _do_request(\&HTTP::Request::Common::PUT    => @_) }
 sub delete { _do_request(\&HTTP::Request::Common::DELETE => @_) }
 sub post   { _do_request(\&HTTP::Request::Common::POST   => @_) }
+sub patch   { _do_request(\&HTTP::Request::Common::PATCH   => @_) }
+sub options   { _do_request(\&HTTP::Request::Common::OPTIONS   => @_) }
 
 sub _do_request {
 	my $cb   = pop();
@@ -322,6 +324,18 @@ function. See L<C<get()>|/get>.
 This method is a wrapper for the L<C<request()>|/request> method and the
 L<C<HTTP::Request::Common::POST()>|HTTP::Request::Common/POST $url> function.
 The last argument must be a callback.
+
+=head2 patch
+
+This method is a wrapper for the L<C<request()>|/request> method and the
+L<C<HTTP::Request::Common::PATCH()>|HTTP::Request::Common/PATCH $url> function.
+The last argument must be a callback.
+
+=head2 options
+
+This method is a wrapper for the L<C<request()>|/request> method and the
+L<C<HTTP::Request::Common::OPTIONS()>|HTTP::Request::Common/OPTIONS $url>
+function. The last argument must be a callback.
 
 =head1 LIMITATIONS
 

--- a/lib/AnyEvent/UserAgent.pm
+++ b/lib/AnyEvent/UserAgent.pm
@@ -13,7 +13,7 @@ use HTTP::Response ();
 
 use namespace::clean;
 
-our $VERSION = '0.08';
+our $VERSION = '0.09';
 
 
 has agent              => (is => 'rw', default => sub { $AnyEvent::HTTP::USERAGENT . ' AnyEvent-UserAgent/' . $VERSION });
@@ -25,6 +25,15 @@ has max_redirects      => (is => 'rw', default => sub { 5 });
 has inactivity_timeout => (is => 'rw', default => sub { 20 });
 
 has request_timeout    => (is => 'rw', default => sub { 0 });
+
+my @OPTIONS = qw(
+	proxy tls_ctx session timeout on_prepare tcp_connect on_header on_body
+	want_body_handle persistent keepalive handle_params
+);
+
+for my $o (@OPTIONS) {
+	has $o => (is => 'rw', default => undef);
+}
 
 sub request {
 	my $cb = pop();
@@ -66,7 +75,7 @@ sub _request {
 		$self->cookie_jar->add_cookie_header($req);
 	}
 
-	for (qw(max_redirects inactivity_timeout request_timeout)) {
+	for (qw(max_redirects inactivity_timeout request_timeout), @OPTIONS) {
 		$opts->{$_} = $self->$_() unless exists($opts->{$_});
 	}
 
@@ -85,9 +94,7 @@ sub _request {
 		body    => $req->content,
 		recurse => 0,
 		timeout => $opts->{inactivity_timeout},
-		(map { $_ => $opts->{$_} } grep { exists($opts->{$_}) }
-			qw(proxy tls_ctx session timeout on_prepare tcp_connect on_header
-			   on_body want_body_handle persistent keepalive handle_params)),
+		(map { $_ => $opts->{$_} } grep { defined($opts->{$_}) } @OPTIONS),
 		sub {
 			undef($grd);
 			undef($tmr);
@@ -247,6 +254,14 @@ a response. The request will be canceled when that time expires. Default timeout
 value is C<0>. Setting the value to C<0> will allow the user agent to wait
 indefinitely. The timeout will reset for every followed redirect.
 
+=head2 Other attributes
+
+The following attributes are supported and they are all passed as options to the
+L<C<AnyEvent::HTTP::http_request>|AnyEvent::HTTP/METHODS> calls made by this
+module: C<proxy>, C<tls_ctx>, C<session>, C<timeout>, C<on_prepare>,
+C<tcp_connect>, C<on_header>, C<on_body>, C<want_body_handle>, C<persistent>,
+C<keepalive>, C<handle_params>.
+
 =head1 METHODS
 
 =head2 new
@@ -307,6 +322,14 @@ function. See L<C<get()>|/get>.
 This method is a wrapper for the L<C<request()>|/request> method and the
 L<C<HTTP::Request::Common::POST()>|HTTP::Request::Common/POST $url> function.
 The last argument must be a callback.
+
+=head1 LIMITATIONS
+
+Because of the handling of redirections done by this module as well as
+L<AnyEvent::HTTP>, if you are connecting to a web server that does not implement
+persistent connections (which is common for test servers) then you should pass a
+C<persistent => 0> option to the C<AnyEvent::UserAgent> constructor otherwise
+some requests might fail.
 
 =head1 SEE ALSO
 

--- a/t/03-options-2.t
+++ b/t/03-options-2.t
@@ -26,18 +26,27 @@ use HTTP::Request::Common ();
 	};
 }
 
-my $ua = AnyEvent::UserAgent->new;
-my $cv = AE::cv;
+{
+	my $ua = AnyEvent::UserAgent->new;
+	my $cv = AE::cv;
 
-$ua->request(
-	HTTP::Request::Common::GET('http://example.com/'),
-	foo        => 'bar',
-	persistent => 1,
-	sub {
-		$cv->send();
-	}
-);
-$cv->recv();
+	$ua->request(
+		HTTP::Request::Common::GET('http://example.com/'),
+		foo        => 'bar',
+		persistent => 1,
+		sub {
+			$cv->send();
+		}
+	);
+	$cv->recv();
+}
 
+{
+	my $ua = AnyEvent::UserAgent->new(persistent => 1);
+	my $cv = AE::cv;
+
+	$ua->get('http://example.com/', sub { $cv->send() });
+	$cv->recv();
+}
 
 done_testing;


### PR DESCRIPTION
Currently options can only be passed to the `AnyEvent::HTTP::http_request` calls when using directly the `AnyEvent::UserAgent::request` method, and not the get/post/... methods. And there is no options to set these options in the constructor of the user agent for all methods. These points are fixed by this change.

The motivation for this change can be found in this [cpan ticket](https://rt.cpan.org/Ticket/Display.html?id=156970).

It is unclear if the actual bug is in `AnyEvent::HTTP` or in `AnyEvent::UserAgent`, but being able to deactivate persistent connections is a simple workaround.

Note: this also adds support for the PATCH and OPTIONS HTTP verbs.